### PR TITLE
Rework workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,15 +24,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-
       - name: Build image
         uses: docker/build-push-action@v2
         with:
           push: false
           context: .
           file: dev/build/Dockerfile
-
-
 
   # Build image and push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
@@ -71,7 +68,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha
+            type=sha,prefix=
 
       - name: Disable dev flag
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,22 +51,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker for tag
-        id: meta_tag
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Extract metadata for Docker
+        id: meta
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
-            type=ref,event=tag
-
-      - name: Extract metadata for Docker on branch
-        id: meta_edge
-        if: false == startsWith(github.ref, 'refs/tags/v')
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
-          tags: |
+            type=ref,event=tag,priority=400
             type=sha,prefix=,priority=200
             type=edge,priority=100
 
@@ -79,38 +70,11 @@ jobs:
         with:
           files: "package.json"
         env:
+          version: ${{ steps.meta.outputs.version }}
           releaseDate: ${{ steps.build_time.outputs.time }}
           repository.url: "git+${{ github.server_url }}/${{ github.repository }}.git"
           bugs.url: "${{ github.server_url }}/${{ github.repository }}/issues"
           homepage: "${{ github.server_url }}/${{ github.repository }}#readme"
-
-      - name: Disable dev flag and set package version for tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: "package.json"
-        env:
-          dev: "false"
-          version: ${{ steps.meta_tag.outputs.version }}
-
-      - name: Set package version for branch
-        if: false == startsWith(github.ref, 'refs/tags/v')
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: "package.json"
-        env:
-          version: ${{ steps.meta_edge.outputs.version }}
-
-      - name: Build and push Docker image for tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: .
-          file: dev/build/Dockerfile
-          tags: ${{ steps.meta_tag.outputs.tags }}
-          labels: ${{ steps.meta_tag.outputs.labels }}
-
 
       - name: Build and push Docker image on branch
         if: false == startsWith(github.ref, 'refs/tags/v')
@@ -119,5 +83,32 @@ jobs:
           push: true
           context: .
           file: dev/build/Dockerfile
-          tags: ${{ steps.meta_edge.outputs.tags }}
-          labels: ${{ steps.meta_edge.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract metadata for Docker for tag
+        id: metatag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+
+      - name: Set dev flag to false in package.json for tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: "package.json"
+        env:
+          dev: "false"
+
+      - name: Build and push Docker image for tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: dev/build/Dockerfile
+          tags: ${{ steps.metatag.outputs.tags }}
+          labels: ${{ steps.metatag.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,6 +110,8 @@ jobs:
           context: .
           file: dev/build/Dockerfile
           tags: ${{ steps.meta_tag.outputs.tags }}
+          labels: ${{ steps.meta_tag.outputs.labels }}
+
 
       - name: Build and push Docker image (bleeding)
         if: false == startsWith(github.ref, 'refs/tags/v')
@@ -119,3 +121,4 @@ jobs:
           context: .
           file: dev/build/Dockerfile
           tags: ${{ steps.meta_bleeding.outputs.tags }}
+          labels: ${{ steps.meta_bleeding.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # Test building the docker image on pull requests
@@ -57,7 +56,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
             type=ref,event=tag
 
@@ -66,7 +65,7 @@ jobs:
         if: false == startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
             type=sha,prefix=,priority=200
             type=raw,value=bleeding,priority=100

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=
+            type=sha,prefix=,priority=200
+            type=raw,value=bleeding,priority=100
 
       - name: Get build time
         uses: gerred/actions/current-time@master
@@ -117,4 +118,4 @@ jobs:
           push: true
           context: .
           file: dev/build/Dockerfile
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:bleeding,${{ steps.meta_bleeding.outputs.tags }}
+          tags: ${{ steps.meta_bleeding.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,29 +70,31 @@ jobs:
           tags: |
             type=sha,prefix=
 
-      - name: Disable dev flag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          sudo apt-get install jq -y
-          mv package.json pkg-temp.json
-          jq -r '.dev |= false' pkg-temp.json > package.json
-          rm pkg-temp.json
+      - name: Rewrite entries in package.json to repository
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: "package.json"
+        env:
+          repository.url: "git+${{ github.server_url }}/${{ github.repository }}.git"
+          bugs.url: "${{ github.server_url }}/${{ github.repository }}/issues"
+          homepage: "${{ github.server_url }}/${{ github.repository }}#readme"
 
-      - name: Set Package Version (tag)
+      - name: Disable dev flag and set package version (tag)
         if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          mv package.json pkg-temp.json
-          jq -r '.version |= "${{ steps.meta_tag.outputs.version }}"' pkg-temp.json > package.json
-          rm pkg-temp.json
-          cat package.json
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: "package.json"
+        env:
+          dev: "false"
+          version: ${{ steps.meta_tag.outputs.version }}
 
-      - name: Set Package Version (bleeding)
+      - name: Set package version (bleeding)
         if: false == startsWith(github.ref, 'refs/tags/v')
-        run: |
-          mv package.json pkg-temp.json
-          jq -r '.version |= "${{ steps.meta_bleeding.outputs.version }}"' pkg-temp.json > package.json
-          rm pkg-temp.json
-          cat package.json
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: "package.json"
+        env:
+          version: ${{ steps.meta_bleeding.outputs.version }}
 
       - name: Build and push Docker image (tag)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker (tag)
+      - name: Extract metadata for Docker for tag
         id: meta_tag
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v3
@@ -60,21 +60,21 @@ jobs:
           tags: |
             type=ref,event=tag
 
-      - name: Extract metadata for Docker (bleeding)
-        id: meta_bleeding
+      - name: Extract metadata for Docker on branch
+        id: meta_edge
         if: false == startsWith(github.ref, 'refs/tags/v')
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
             type=sha,prefix=,priority=200
-            type=raw,value=bleeding,priority=100
+            type=edge,priority=100
 
       - name: Get build time
         uses: gerred/actions/current-time@master
         id: build_time
 
-      - name: Rewrite entries in package.json to repository
+      - name: Rewrite entries in package.json to match repository
         uses: microsoft/variable-substitution@v1
         with:
           files: "package.json"
@@ -84,7 +84,7 @@ jobs:
           bugs.url: "${{ github.server_url }}/${{ github.repository }}/issues"
           homepage: "${{ github.server_url }}/${{ github.repository }}#readme"
 
-      - name: Disable dev flag and set package version (tag)
+      - name: Disable dev flag and set package version for tag
         if: startsWith(github.ref, 'refs/tags/v')
         uses: microsoft/variable-substitution@v1
         with:
@@ -93,15 +93,15 @@ jobs:
           dev: "false"
           version: ${{ steps.meta_tag.outputs.version }}
 
-      - name: Set package version (bleeding)
+      - name: Set package version for branch
         if: false == startsWith(github.ref, 'refs/tags/v')
         uses: microsoft/variable-substitution@v1
         with:
           files: "package.json"
         env:
-          version: ${{ steps.meta_bleeding.outputs.version }}
+          version: ${{ steps.meta_edge.outputs.version }}
 
-      - name: Build and push Docker image (tag)
+      - name: Build and push Docker image for tag
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v2
         with:
@@ -112,12 +112,12 @@ jobs:
           labels: ${{ steps.meta_tag.outputs.labels }}
 
 
-      - name: Build and push Docker image (bleeding)
+      - name: Build and push Docker image on branch
         if: false == startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v2
         with:
           push: true
           context: .
           file: dev/build/Dockerfile
-          tags: ${{ steps.meta_bleeding.outputs.tags }}
-          labels: ${{ steps.meta_bleeding.outputs.labels }}
+          tags: ${{ steps.meta_edge.outputs.tags }}
+          labels: ${{ steps.meta_edge.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,11 +70,16 @@ jobs:
           tags: |
             type=sha,prefix=
 
+      - name: Get build time
+        uses: gerred/actions/current-time@master
+        id: build_time
+
       - name: Rewrite entries in package.json to repository
         uses: microsoft/variable-substitution@v1
         with:
           files: "package.json"
         env:
+          releaseDate: ${{ steps.build_time.outputs.time }}
           repository.url: "git+${{ github.server_url }}/${{ github.repository }}.git"
           bugs.url: "${{ github.server_url }}/${{ github.repository }}/issues"
           homepage: "${{ github.server_url }}/${{ github.repository }}#readme"


### PR DESCRIPTION
This pull request rewrites the docker workflow in various ways:

- Use non-prefixed short-sha for rolling image
- Use microsoft/variable-substitution to rewrite the package.json instead of manual jq intervention
- Add action to get ISO8061 timestamp to add to package.json
- Add opencontainer labels to container generated by extract-metadata action
- Rework bleeding build
- Use `type=edge` from extract-metadata instead of bleeding tagging